### PR TITLE
Update BinaryMask.php

### DIFF
--- a/php-mysql-varbinary/BinaryMask.php
+++ b/php-mysql-varbinary/BinaryMask.php
@@ -1,3 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
 class BinaryMask
 {
 	protected static int $indexOffset = 0;
@@ -58,10 +62,10 @@ class BinaryMask
 
 		$res = array_fill(0, $sizeInBytes, 0);
 		$reverseIndexBase = $sizeInBytes - 1;
+		$adjust = $indexOffset + $shiftedBits;
 
 		foreach ($bits as $bit) {
-			$bit -= $indexOffset;
-			$bit -= $shiftedBits;
+			$bit -= $adjust;
 
 			$res[$reverseIndexBase - ($bit >> 3)] |= 1 << ($bit & 7);
 		}
@@ -109,13 +113,13 @@ class BinaryMask
 		}
 
 		$pos = 0;
-		$parts = array_fill(0, $count, 0);
+		$binTable = self::$binTable;
 
 		foreach ($bytes as $byte) {
-			$parts[$pos++] = self::$binTable[$byte];
+			$bytes[$pos++] = $binTable[$byte];
 		}
 
-		return implode($split ? ' ' : '', $parts);
+		return implode($split ? ' ' : '', $bytes);
 	}
 
 	/**
@@ -139,17 +143,19 @@ class BinaryMask
 		}
 
 		$pos = 0;
-		$parts = array_fill(0, $count, 0);
+		$hexTable = self::$hexTable;
 
 		foreach ($bytes as $byte) {
-			$parts[$pos++] = self::$hexTable[$byte];
+			$bytes[$pos++] = $hexTable[$byte];
 		}
 
-		return implode($split ? ' ' : '', $parts);
+		return implode($split ? ' ' : '', $bytes);
 	}
 
 	/**
 	 * Decode packed binary string into bit indexes.
+	 *
+	 * Optimized version.
 	 *
 	 * @return array<int>
 	 */
@@ -161,35 +167,40 @@ class BinaryMask
 			return [];
 		}
 
-		$res = [];
-		$sizeInBytes = strlen($data);
-		$basic = ($shifted << 3) + static::$indexOffset;
-		$bitIndexMap = [
-			1 => 0,
-			2 => 1,
-			4 => 2,
-			8 => 3,
-			16 => 4,
-			32 => 5,
-			64 => 6,
-			128 => 7,
-		];
+		static $decodeTable = null;
 
-		for ($i = $sizeInBytes - 1; $i >= 0; $i--) {
+		if ($decodeTable === null) {
+			$decodeTable = [];
+
+			for ($byte = 0; $byte < 256; $byte++) {
+				$bits = [];
+
+				for ($bit = 0; $bit < 8; $bit++) {
+					if ($byte & (1 << $bit)) {
+						$bits[] = $bit;
+					}
+				}
+
+				$decodeTable[$byte] = $bits;
+			}
+		}
+
+		$res = [];
+
+		$lastByte = strlen($data) - 1;
+		$base = ($shifted << 3) + static::$indexOffset;
+
+		for ($i = $lastByte; $i >= 0; $i--) {
 			$byte = ord($data[$i]);
 
 			if ($byte === 0) {
 				continue;
 			}
 
-			$base = (($sizeInBytes - $i - 1) << 3) + $basic;
+			$currentBase = (($lastByte - $i) << 3) + $base;
 
-			while ($byte !== 0) {
-				$lsb = $byte & (-$byte);
-
-				$res[] = $base + $bitIndexMap[$lsb];
-
-				$byte ^= $lsb;
+			foreach ($decodeTable[$byte] as $bit) {
+				$res[] = $currentBase + $bit;
 			}
 		}
 

--- a/php-mysql-varbinary/BinaryMask.php
+++ b/php-mysql-varbinary/BinaryMask.php
@@ -1,98 +1,220 @@
-<?php
+class BinaryMask
+{
+	protected static int $indexOffset = 0;
 
-class BinaryMask {
-	public static function toBytes(array $bits, $shift = false, &$shifted = 0) {
-		$res = [];
-		$shifted = 0;
-		if (!$bits)
-			return [];
-		$minBit = min($bits);
-		if ($minBit < 0)
-			throw new Exception('Each element in the $bits array should be >=0');
-		$maxBit = max($bits);
-		if ($shift)
-			$shifted = (int) floor($minBit / 8);
-		$shiftedBits = $shifted * 8;
-		$sizeInBytes = (int) ceil(($maxBit + 1) / 8) - $shifted;
-		if (!$sizeInBytes)
-			return [];
-		$res = array_fill(0, $sizeInBytes, 0);
-		foreach ($bits as $bit) {
-			$bit = ((int) $bit) - $shiftedBits;
-			/*
-			// non-optimized code:
-			$byteIndex = $sizeInBytes - floor($bit / 8) - 1;
-			$bitPosition = $bit % 8;
-			$res[$byteIndex] |= 1 << $bitPosition;
-			continue;
-			*/
-			$res[$sizeInBytes - ((int) ($bit / 8)) - 1] |= 1 << ($bit % 8);
+	protected static array $binTable = [];
+
+	protected static array $hexTable = [];
+
+	protected static function initTables(): void
+	{
+		if (self::$binTable) {
+			return;
 		}
+
+		for ($i = 0; $i < 256; $i++) {
+			self::$binTable[$i] = sprintf('%08b', $i);
+			self::$hexTable[$i] = sprintf('%02x', $i);
+		}
+	}
+
+	/**
+	 * Convert bit indexes into byte array.
+	 *
+	 * @param array<int> $bits
+	 * @param bool $shift
+	 * @param int $shifted
+	 * @return array<int>
+	 */
+	public static function toBytes(
+		array $bits,
+		bool $shift = false,
+		int &$shifted = 0
+	): array {
+		if (!$bits) {
+			$shifted = 0;
+
+			return [];
+		}
+
+		$indexOffset = static::$indexOffset;
+		$minBit = min($bits);
+		$minBit -= $indexOffset;
+
+		if ($minBit < 0) {
+			throw new Exception('Each element in the $bits array should be >=0');
+		}
+
+		$maxBit = max($bits);
+		$maxBit -= $indexOffset;
+
+		$shifted = $shift ? ($minBit >> 3) : 0;
+		$shiftedBits = $shifted << 3;
+		$sizeInBytes = (($maxBit + 8) >> 3) - $shifted;
+
+		if ($sizeInBytes <= 0) {
+			return [];
+		}
+
+		$res = array_fill(0, $sizeInBytes, 0);
+		$reverseIndexBase = $sizeInBytes - 1;
+
+		foreach ($bits as $bit) {
+			$bit -= $indexOffset;
+			$bit -= $shiftedBits;
+
+			$res[$reverseIndexBase - ($bit >> 3)] |= 1 << ($bit & 7);
+		}
+
 		return $res;
 	}
-	
-	public static function toBinData(array $bits, $shift = false, &$shifted = 0) {
-		return call_user_func_array('pack', array_merge(['C*'], static::toBytes($bits, $shift, $shifted)));
+
+	/**
+	 * Convert bit indexes into packed binary string.
+	 *
+	 * @param array<int> $bits
+	 */
+	public static function toBinData(
+		array $bits,
+		bool $shift = false,
+		int &$shifted = 0
+	): string {
+		$bytes = static::toBytes($bits, $shift, $shifted);
+
+		if (!$bytes) {
+			return '';
+		}
+
+		return pack('C*', ...$bytes);
 	}
-	
-	public static function toBinString(array $bits, $split = false, $shift = false, &$shifted = 0) {
-		return implode($split ? ' ' : '', array_map(function ($byte) {
-			return substr('00000000'.decbin($byte), -8);
-		}, static::toBytes($bits, $shift, $shifted)));
+
+	/**
+	 * Convert bit indexes into binary string.
+	 *
+	 * @param array<int> $bits
+	 */
+	public static function toBinString(
+		array $bits,
+		bool $split = false,
+		bool $shift = false,
+		int &$shifted = 0
+	): string {
+		self::initTables();
+
+		$bytes = static::toBytes($bits, $shift, $shifted);
+		$count = count($bytes);
+
+		if ($count === 0) {
+			return '';
+		}
+
+		$pos = 0;
+		$parts = array_fill(0, $count, 0);
+
+		foreach ($bytes as $byte) {
+			$parts[$pos++] = self::$binTable[$byte];
+		}
+
+		return implode($split ? ' ' : '', $parts);
 	}
-	
-	public static function toHexString(array $bits, $split = false, $shift = false, &$shifted = 0) {
-		return implode($split ? ' ' : '', array_map(function ($byte) {
-			return substr('00'.dechex($byte), -2);
-		}, static::toBytes($bits, $shift, $shifted)));
+
+	/**
+	 * Convert bit indexes into hexadecimal string.
+	 *
+	 * @param array<int> $bits
+	 */
+	public static function toHexString(
+		array $bits,
+		bool $split = false,
+		bool $shift = false,
+		int &$shifted = 0
+	): string {
+		self::initTables();
+
+		$bytes = static::toBytes($bits, $shift, $shifted);
+		$count = count($bytes);
+
+		if ($count === 0) {
+			return '';
+		}
+
+		$pos = 0;
+		$parts = array_fill(0, $count, 0);
+
+		foreach ($bytes as $byte) {
+			$parts[$pos++] = self::$hexTable[$byte];
+		}
+
+		return implode($split ? ' ' : '', $parts);
 	}
-	
-	public static function fromBinData($data, $shifted = 0) {
+
+	/**
+	 * Decode packed binary string into bit indexes.
+	 *
+	 * @return array<int>
+	 */
+	public static function fromBinData(
+		string $data,
+		int $shifted = 0
+	): array {
+		if ($data === '') {
+			return [];
+		}
+
 		$res = [];
 		$sizeInBytes = strlen($data);
-		$data = unpack('C*', $data);
-		$sizeInBytes = count($data);
-		$shiftedBits = $shifted * 8;
-		for ($i = $sizeInBytes - 1; $i > -1; $i--) {
-			$byte = $data[$i + 1];
-			$bitIndex = 0;
-			while ($byte && $bitIndex < 8) {
-				if ($byte & 1)
-					$res[] = ($sizeInBytes - $i - 1) * 8 + $bitIndex + $shiftedBits;
-				$byte >>= 1;
-				$bitIndex++;
+		$basic = ($shifted << 3) + static::$indexOffset;
+		$bitIndexMap = [
+			1 => 0,
+			2 => 1,
+			4 => 2,
+			8 => 3,
+			16 => 4,
+			32 => 5,
+			64 => 6,
+			128 => 7,
+		];
+
+		for ($i = $sizeInBytes - 1; $i >= 0; $i--) {
+			$byte = ord($data[$i]);
+
+			if ($byte === 0) {
+				continue;
+			}
+
+			$base = (($sizeInBytes - $i - 1) << 3) + $basic;
+
+			while ($byte !== 0) {
+				$lsb = $byte & (-$byte);
+
+				$res[] = $base + $bitIndexMap[$lsb];
+
+				$byte ^= $lsb;
 			}
 		}
+
 		return $res;
 	}
-	
-	public static function getSqlCondition($column, $bit, $shiftColumn = null) {
-		if (!$shiftColumn)
+
+	/**
+	 * Generate SQL condition for testing a bit.
+	 */
+	public static function getSqlCondition(
+		string $column,
+		int $bit,
+		?string $shiftColumn = null
+	): string {
+		$bit -= static::$indexOffset;
+
+		if ($shiftColumn === null) {
 			return "ASCII(SUBSTR($column, -CEIL(($bit) / 8), 1)) & (1 << (($bit) % 8))";
-		else
-			return "ASCII(SUBSTR($column, -(CEIL(($bit) / 8) - $shiftColumn), 1)) & (1 << (($bit) % 8))";
+		}
+
+		return "ASCII(SUBSTR($column, -(CEIL(($bit) / 8) - $shiftColumn), 1)) & (1 << (($bit) % 8))";
 	}
 }
 
-class BinaryIds extends BinaryMask {
-	protected static function decrease($number) {
-		return $number - 1;
-	}
-	
-	protected static function increase($number) {
-		return $number + 1;
-	}
-	
-	public static function toBytes(array $ids, $shift = false, &$shifted = 0) {
-		return parent::toBytes(array_map('self::decrease', $ids), $shift, $shifted);
-	}
-	
-	public static function fromBinData($data, $shifted = 0) {
-		return array_map('self::increase', parent::fromBinData($data, $shifted));
-	}
-	
-	public static function getSqlCondition($column, $id, $shiftColumn = null) {
-		return parent::getSqlCondition($column, "$id - 1", $shiftColumn);
-	}
-	
+class BinaryIds extends BinaryMask
+{
+	protected static int $indexOffset = 1;
 }


### PR DESCRIPTION
Now at least 25% faster

```
========================================================================================================================
BinaryMask Benchmark
========================================================================================================================

Dataset: small_sparse
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD     1220.6 ns | NEW      932.0 ns |    1.31x faster |   23.64% improvement
toBinData()                      | OLD     1773.1 ns | NEW     1298.3 ns |    1.37x faster |   26.78% improvement
toBinString()                    | OLD     7707.2 ns | NEW     2543.6 ns |    3.03x faster |   67.00% improvement
toHexString()                    | OLD     7216.9 ns | NEW     2541.9 ns |    2.84x faster |   64.78% improvement
fromBinData()                    | OLD     4558.7 ns | NEW     2623.3 ns |    1.74x faster |   42.46% improvement
BinaryIds::toBytes()             | OLD     1952.8 ns | NEW      942.9 ns |    2.07x faster |   51.72% improvement
BinaryIds::fromBinData()         | OLD     5231.7 ns | NEW     2617.7 ns |    2.00x faster |   49.96% improvement

Dataset: medium_sparse
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD     7400.7 ns | NEW     5688.3 ns |    1.30x faster |   23.14% improvement
toBinData()                      | OLD    12019.6 ns | NEW     8675.7 ns |    1.39x faster |   27.82% improvement
toBinString()                    | OLD   118916.8 ns | NEW    30212.2 ns |    3.94x faster |   74.59% improvement
toHexString()                    | OLD   111382.0 ns | NEW    30289.8 ns |    3.68x faster |   72.81% improvement
fromBinData()                    | OLD    54771.5 ns | NEW    37515.3 ns |    1.46x faster |   31.51% improvement
BinaryIds::toBytes()             | OLD    10777.0 ns | NEW     5672.1 ns |    1.90x faster |   47.37% improvement
BinaryIds::fromBinData()         | OLD    58614.8 ns | NEW    37696.1 ns |    1.55x faster |   35.69% improvement

Dataset: large_sparse
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD    68315.3 ns | NEW    53731.2 ns |    1.27x faster |   21.35% improvement
toBinData()                      | OLD   138122.6 ns | NEW   100847.6 ns |    1.37x faster |   26.99% improvement
toBinString()                    | OLD  1880011.2 ns | NEW   456020.8 ns |    4.12x faster |   75.74% improvement
toHexString()                    | OLD  1725384.2 ns | NEW   452879.9 ns |    3.81x faster |   73.75% improvement
fromBinData()                    | OLD   729188.7 ns | NEW   572532.8 ns |    1.27x faster |   21.48% improvement
BinaryIds::toBytes()             | OLD    95148.8 ns | NEW    54868.5 ns |    1.73x faster |   42.33% improvement
BinaryIds::fromBinData()         | OLD   775428.8 ns | NEW   572039.0 ns |    1.36x faster |   26.23% improvement

Dataset: small_sorted
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD     1232.9 ns | NEW      924.7 ns |    1.33x faster |   25.00% improvement
toBinData()                      | OLD     1787.3 ns | NEW     1293.1 ns |    1.38x faster |   27.65% improvement
toBinString()                    | OLD     8493.0 ns | NEW     2707.1 ns |    3.14x faster |   68.13% improvement
toHexString()                    | OLD     7676.9 ns | NEW     2693.7 ns |    2.85x faster |   64.91% improvement
fromBinData()                    | OLD     5193.1 ns | NEW     2786.5 ns |    1.86x faster |   46.34% improvement
BinaryIds::toBytes()             | OLD     1959.7 ns | NEW      959.4 ns |    2.04x faster |   51.04% improvement
BinaryIds::fromBinData()         | OLD     5846.0 ns | NEW     2763.2 ns |    2.12x faster |   52.73% improvement

Dataset: medium_sorted
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD     7643.7 ns | NEW     5788.1 ns |    1.32x faster |   24.28% improvement
toBinData()                      | OLD    12321.8 ns | NEW     8589.6 ns |    1.43x faster |   30.29% improvement
toBinString()                    | OLD   119640.0 ns | NEW    30889.6 ns |    3.87x faster |   74.18% improvement
toHexString()                    | OLD   111768.0 ns | NEW    30395.8 ns |    3.68x faster |   72.80% improvement
fromBinData()                    | OLD    54949.2 ns | NEW    38414.6 ns |    1.43x faster |   30.09% improvement
BinaryIds::toBytes()             | OLD    11072.5 ns | NEW     5752.9 ns |    1.92x faster |   48.04% improvement
BinaryIds::fromBinData()         | OLD    59108.0 ns | NEW    38414.2 ns |    1.54x faster |   35.01% improvement

Dataset: large_sorted
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD    70302.4 ns | NEW    55283.3 ns |    1.27x faster |   21.36% improvement
toBinData()                      | OLD   140245.0 ns | NEW   101995.7 ns |    1.38x faster |   27.27% improvement
toBinString()                    | OLD  1883630.6 ns | NEW   455217.7 ns |    4.14x faster |   75.83% improvement
toHexString()                    | OLD  1725230.4 ns | NEW   451514.9 ns |    3.82x faster |   73.83% improvement
fromBinData()                    | OLD   730900.9 ns | NEW   573442.0 ns |    1.27x faster |   21.54% improvement
BinaryIds::toBytes()             | OLD    95401.4 ns | NEW    55472.7 ns |    1.72x faster |   41.85% improvement
BinaryIds::fromBinData()         | OLD   759066.9 ns | NEW   588871.7 ns |    1.29x faster |   22.42% improvement

Dataset: empty
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD       89.1 ns | NEW       89.4 ns |    1.00x faster |   -0.33% improvement
toBinData()                      | OLD      251.0 ns | NEW      132.2 ns |    1.90x faster |   47.32% improvement
toBinString()                    | OLD      238.6 ns | NEW      178.4 ns |    1.34x faster |   25.25% improvement
toHexString()                    | OLD      232.7 ns | NEW      175.0 ns |    1.33x faster |   24.80% improvement
fromBinData()                    | OLD      126.8 ns | NEW       64.5 ns |    1.97x faster |   49.13% improvement
BinaryIds::toBytes()             | OLD      218.6 ns | NEW       87.9 ns |    2.49x faster |   59.81% improvement
BinaryIds::fromBinData()         | OLD      255.5 ns | NEW       65.4 ns |    3.91x faster |   74.40% improvement

Dataset: single_zero
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD      376.6 ns | NEW      333.9 ns |    1.13x faster |   11.35% improvement
toBinData()                      | OLD      606.0 ns | NEW      506.9 ns |    1.20x faster |   16.35% improvement
toBinString()                    | OLD      747.8 ns | NEW      590.5 ns |    1.27x faster |   21.04% improvement
toHexString()                    | OLD      724.4 ns | NEW      593.3 ns |    1.22x faster |   18.09% improvement
fromBinData()                    | OLD      290.4 ns | NEW      229.6 ns |    1.26x faster |   20.93% improvement
BinaryIds::toBytes()             | OLD      642.4 ns | NEW      333.2 ns |    1.93x faster |   48.14% improvement
BinaryIds::fromBinData()         | OLD      510.7 ns | NEW      227.7 ns |    2.24x faster |   55.43% improvement

Dataset: single_one
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD      378.6 ns | NEW      333.3 ns |    1.14x faster |   11.94% improvement
toBinData()                      | OLD      625.5 ns | NEW      494.6 ns |    1.26x faster |   20.94% improvement
toBinString()                    | OLD      744.2 ns | NEW      590.0 ns |    1.26x faster |   20.72% improvement
toHexString()                    | OLD      741.6 ns | NEW      592.0 ns |    1.25x faster |   20.17% improvement
fromBinData()                    | OLD      301.4 ns | NEW      229.5 ns |    1.31x faster |   23.86% improvement
BinaryIds::toBytes()             | OLD      624.8 ns | NEW      330.1 ns |    1.89x faster |   47.17% improvement
BinaryIds::fromBinData()         | OLD      511.7 ns | NEW      230.1 ns |    2.22x faster |   55.03% improvement

Dataset: single_high
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD      381.5 ns | NEW      331.3 ns |    1.15x faster |   13.16% improvement
toBinData()                      | OLD      594.4 ns | NEW      497.6 ns |    1.19x faster |   16.29% improvement
toBinString()                    | OLD      752.8 ns | NEW      587.4 ns |    1.28x faster |   21.97% improvement
toHexString()                    | OLD      729.6 ns | NEW      585.0 ns |    1.25x faster |   19.82% improvement
fromBinData()                    | OLD      259.4 ns | NEW      235.4 ns |    1.10x faster |    9.25% improvement
BinaryIds::toBytes()             | OLD      642.7 ns | NEW      336.6 ns |    1.91x faster |   47.63% improvement
BinaryIds::fromBinData()         | OLD      514.2 ns | NEW      230.7 ns |    2.23x faster |   55.14% improvement

Dataset: byte_boundary
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD      618.6 ns | NEW      497.0 ns |    1.24x faster |   19.66% improvement
toBinData()                      | OLD      812.8 ns | NEW      642.0 ns |    1.27x faster |   21.01% improvement
toBinString()                    | OLD     1211.4 ns | NEW      802.5 ns |    1.51x faster |   33.75% improvement
toHexString()                    | OLD     1175.9 ns | NEW      807.8 ns |    1.46x faster |   31.30% improvement
fromBinData()                    | OLD      879.4 ns | NEW      389.3 ns |    2.26x faster |   55.73% improvement
BinaryIds::toBytes()             | OLD      889.6 ns | NEW      463.1 ns |    1.92x faster |   47.95% improvement
BinaryIds::fromBinData()         | OLD     1203.3 ns | NEW      390.9 ns |    3.08x faster |   67.51% improvement

Dataset: dense_small
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD    13134.6 ns | NEW     8840.6 ns |    1.49x faster |   32.69% improvement
toBinData()                      | OLD    13681.0 ns | NEW     9117.5 ns |    1.50x faster |   33.36% improvement
toBinString()                    | OLD    17390.3 ns | NEW     9969.2 ns |    1.74x faster |   42.67% improvement
toHexString()                    | OLD    17346.1 ns | NEW     9881.5 ns |    1.76x faster |   43.03% improvement
fromBinData()                    | OLD    13688.5 ns | NEW     6182.8 ns |    2.21x faster |   54.83% improvement
BinaryIds::toBytes()             | OLD    20097.6 ns | NEW     8866.7 ns |    2.27x faster |   55.88% improvement
BinaryIds::fromBinData()         | OLD    20819.9 ns | NEW     6214.3 ns |    3.35x faster |   70.15% improvement

Dataset: dense_large
------------------------------------------------------------------------------------------------------------------------
toBytes()                        | OLD   205244.3 ns | NEW   136423.3 ns |    1.50x faster |   33.53% improvement
toBinData()                      | OLD   211695.6 ns | NEW   138053.9 ns |    1.53x faster |   34.79% improvement
toBinString()                    | OLD   266266.5 ns | NEW   148455.7 ns |    1.79x faster |   44.25% improvement
toHexString()                    | OLD   260399.0 ns | NEW   148366.7 ns |    1.76x faster |   43.02% improvement
fromBinData()                    | OLD   209684.6 ns | NEW    93266.8 ns |    2.25x faster |   55.52% improvement
BinaryIds::toBytes()             | OLD   306540.5 ns | NEW   136328.3 ns |    2.25x faster |   55.53% improvement
BinaryIds::fromBinData()         | OLD   317181.0 ns | NEW    92194.7 ns |    3.44x faster |   70.93% improvement

========================================================================================================================
Done.
========================================================================================================================
```

My benchmark also checks correctness and whether roundtrips work. All tests pass.

```php
<?php

declare(strict_types=1);

ini_set('memory_limit', '2048M');
error_reporting(E_ALL);




class BinaryMask {
	public static function toBytes(array $bits, $shift = false, &$shifted = 0) {
		$res = [];
		$shifted = 0;
		if (!$bits)
			return [];
		$minBit = min($bits);
		if ($minBit < 0)
			throw new Exception('Each element in the $bits array should be >=0');
		$maxBit = max($bits);
		if ($shift)
			$shifted = (int) floor($minBit / 8);
		$shiftedBits = $shifted * 8;
		$sizeInBytes = (int) ceil(($maxBit + 1) / 8) - $shifted;
		if (!$sizeInBytes)
			return [];
		$res = array_fill(0, $sizeInBytes, 0);
		foreach ($bits as $bit) {
			$bit = ((int) $bit) - $shiftedBits;
			/*
			// non-optimized code:
			$byteIndex = $sizeInBytes - floor($bit / 8) - 1;
			$bitPosition = $bit % 8;
			$res[$byteIndex] |= 1 << $bitPosition;
			continue;
			*/
			$res[$sizeInBytes - ((int) ($bit / 8)) - 1] |= 1 << ($bit % 8);
		}
		return $res;
	}
	
	public static function toBinData(array $bits, $shift = false, &$shifted = 0) {
		return call_user_func_array('pack', array_merge(['C*'], static::toBytes($bits, $shift, $shifted)));
	}
	
	public static function toBinString(array $bits, $split = false, $shift = false, &$shifted = 0) {
		return implode($split ? ' ' : '', array_map(function ($byte) {
			return substr('00000000'.decbin($byte), -8);
		}, static::toBytes($bits, $shift, $shifted)));
	}
	
	public static function toHexString(array $bits, $split = false, $shift = false, &$shifted = 0) {
		return implode($split ? ' ' : '', array_map(function ($byte) {
			return substr('00'.dechex($byte), -2);
		}, static::toBytes($bits, $shift, $shifted)));
	}
	
	public static function fromBinData($data, $shifted = 0) {
		$res = [];
		$sizeInBytes = strlen($data);
		$data = unpack('C*', $data);
		$sizeInBytes = count($data);
		$shiftedBits = $shifted * 8;
		for ($i = $sizeInBytes - 1; $i > -1; $i--) {
			$byte = $data[$i + 1];
			$bitIndex = 0;
			while ($byte && $bitIndex < 8) {
				if ($byte & 1)
					$res[] = ($sizeInBytes - $i - 1) * 8 + $bitIndex + $shiftedBits;
				$byte >>= 1;
				$bitIndex++;
			}
		}
		return $res;
	}
	
	public static function getSqlCondition($column, $bit, $shiftColumn = null) {
		if (!$shiftColumn)
			return "ASCII(SUBSTR($column, -CEIL(($bit) / 8), 1)) & (1 << (($bit) % 8))";
		else
			return "ASCII(SUBSTR($column, -(CEIL(($bit) / 8) - $shiftColumn), 1)) & (1 << (($bit) % 8))";
	}
}

class BinaryIds extends BinaryMask {
	protected static function decrease($number) {
		return $number - 1;
	}
	
	protected static function increase($number) {
		return $number + 1;
	}
	
	public static function toBytes(array $ids, $shift = false, &$shifted = 0) {
		return parent::toBytes(array_map(self::decrease(...), $ids), $shift, $shifted);
	}
	
	public static function fromBinData($data, $shifted = 0) {
		return array_map(self::increase(...), parent::fromBinData($data, $shifted));
	}
	
	public static function getSqlCondition($column, $id, $shiftColumn = null) {
		return parent::getSqlCondition($column, "$id - 1", $shiftColumn);
	}
	
}

class BinaryMaskNew
{
	protected static int $indexOffset = 0;

	protected static array $binTable = [];

	protected static array $hexTable = [];

	protected static function initTables(): void
	{
		if (self::$binTable) {
			return;
		}

		for ($i = 0; $i < 256; $i++) {
			self::$binTable[$i] = sprintf('%08b', $i);
			self::$hexTable[$i] = sprintf('%02x', $i);
		}
	}

	/**
	 * Convert bit indexes into byte array.
	 *
	 * @param array<int> $bits
	 * @param bool $shift
	 * @param int $shifted
	 * @return array<int>
	 */
	public static function toBytes(
		array $bits,
		bool $shift = false,
		int &$shifted = 0
	): array {
		if (!$bits) {
			$shifted = 0;

			return [];
		}

		$indexOffset = static::$indexOffset;
		$minBit = min($bits);
		$minBit -= $indexOffset;

		if ($minBit < 0) {
			throw new Exception('Each element in the $bits array should be >=0');
		}

		$maxBit = max($bits);
		$maxBit -= $indexOffset;

		$shifted = $shift ? ($minBit >> 3) : 0;
		$shiftedBits = $shifted << 3;
		$sizeInBytes = (($maxBit + 8) >> 3) - $shifted;

		if ($sizeInBytes <= 0) {
			return [];
		}

		$res = array_fill(0, $sizeInBytes, 0);
		$reverseIndexBase = $sizeInBytes - 1;
		$adjust = $indexOffset + $shiftedBits;

		foreach ($bits as $bit) {
			$bit -= $adjust;

			$res[$reverseIndexBase - ($bit >> 3)] |= 1 << ($bit & 7);
		}

		return $res;
	}

	/**
	 * Convert bit indexes into packed binary string.
	 *
	 * @param array<int> $bits
	 */
	public static function toBinData(
		array $bits,
		bool $shift = false,
		int &$shifted = 0
	): string {
		$bytes = static::toBytes($bits, $shift, $shifted);

		if (!$bytes) {
			return '';
		}

		return pack('C*', ...$bytes);
	}

	/**
	 * Convert bit indexes into binary string.
	 *
	 * @param array<int> $bits
	 */
	public static function toBinString(
		array $bits,
		bool $split = false,
		bool $shift = false,
		int &$shifted = 0
	): string {
		self::initTables();

		$bytes = static::toBytes($bits, $shift, $shifted);
		$count = count($bytes);

		if ($count === 0) {
			return '';
		}

		$pos = 0;
		$binTable = self::$binTable;

		foreach ($bytes as $byte) {
			$bytes[$pos++] = $binTable[$byte];
		}

		return implode($split ? ' ' : '', $bytes);
	}

	/**
	 * Convert bit indexes into hexadecimal string.
	 *
	 * @param array<int> $bits
	 */
	public static function toHexString(
		array $bits,
		bool $split = false,
		bool $shift = false,
		int &$shifted = 0
	): string {
		self::initTables();

		$bytes = static::toBytes($bits, $shift, $shifted);
		$count = count($bytes);

		if ($count === 0) {
			return '';
		}

		$pos = 0;
		$hexTable = self::$hexTable;

		foreach ($bytes as $byte) {
			$bytes[$pos++] = $hexTable[$byte];
		}

		return implode($split ? ' ' : '', $bytes);
	}

	/**
	 * Decode packed binary string into bit indexes.
	 *
	 * Optimized version.
	 *
	 * @return array<int>
	 */
	public static function fromBinData(
		string $data,
		int $shifted = 0
	): array {
		if ($data === '') {
			return [];
		}

		static $decodeTable = null;

		if ($decodeTable === null) {
			$decodeTable = [];

			for ($byte = 0; $byte < 256; $byte++) {
				$bits = [];

				for ($bit = 0; $bit < 8; $bit++) {
					if ($byte & (1 << $bit)) {
						$bits[] = $bit;
					}
				}

				$decodeTable[$byte] = $bits;
			}
		}

		$res = [];

		$lastByte = strlen($data) - 1;
		$base = ($shifted << 3) + static::$indexOffset;

		for ($i = $lastByte; $i >= 0; $i--) {
			$byte = ord($data[$i]);

			if ($byte === 0) {
				continue;
			}

			$currentBase = (($lastByte - $i) << 3) + $base;

			foreach ($decodeTable[$byte] as $bit) {
				$res[] = $currentBase + $bit;
			}
		}

		return $res;
	}

	/**
	 * Generate SQL condition for testing a bit.
	 */
	public static function getSqlCondition(
		string $column,
		int $bit,
		?string $shiftColumn = null
	): string {
		$bit -= static::$indexOffset;

		if ($shiftColumn === null) {
			return "ASCII(SUBSTR($column, -CEIL(($bit) / 8), 1)) & (1 << (($bit) % 8))";
		}

		return "ASCII(SUBSTR($column, -(CEIL(($bit) / 8) - $shiftColumn), 1)) & (1 << (($bit) % 8))";
	}
}

class BinaryIdsNew extends BinaryMaskNew
{
	protected static int $indexOffset = 1;
}


mt_srand(123456789);

/**
 * Generate deterministic unique bits.
 *
 * @return array<int>
 */
function generateBits(
	int $count,
	int $maxBit,
	bool $sorted = false
): array {
	if ($count > ($maxBit + 1)) {
		throw new InvalidArgumentException(
			'Cannot generate more unique bits than available range'
		);
	}

	$bits = [];

	while (count($bits) < $count) {
		$bits[mt_rand(0, $maxBit)] = true;
	}

	$bits = array_keys($bits);

	if ($sorted) {
		sort($bits, SORT_NUMERIC);
	}

	return $bits;
}

/**
 * Benchmark helper.
 */
function benchmark(
	string $label,
	callable $fn,
	int $iterations = 10000
): array {
	gc_collect_cycles();

	$startMem = memory_get_usage(true);
	$startPeak = memory_get_peak_usage(true);

	$start = hrtime(true);

	for ($i = 0; $i < $iterations; $i++) {
		$fn();
	}

	$elapsed = hrtime(true) - $start;

	$endMem = memory_get_usage(true);
	$endPeak = memory_get_peak_usage(true);

	return [
		'label' => $label,
		'iterations' => $iterations,
		'total_ns' => $elapsed,
		'total_ms' => $elapsed / 1_000_000,
		'avg_ns' => $elapsed / $iterations,
		'memory_delta_kb' => ($endMem - $startMem) / 1024,
		'peak_delta_kb' => ($endPeak - $startPeak) / 1024,
	];
}

/**
 * Compare old vs new implementation.
 */
function benchmarkComparison(
	string $label,
	callable $oldFn,
	callable $newFn,
	int $iterations
): array {
	$old = benchmark($label . ' OLD', $oldFn, $iterations);
	$new = benchmark($label . ' NEW', $newFn, $iterations);

	$speedup = $old['avg_ns'] / $new['avg_ns'];

	$percent = (
		($old['avg_ns'] - $new['avg_ns'])
		/ $old['avg_ns']
	) * 100;

	return [
		'label' => $label,
		'iterations' => $iterations,

		'old_avg_ns' => $old['avg_ns'],
		'new_avg_ns' => $new['avg_ns'],

		'old_total_ms' => $old['total_ms'],
		'new_total_ms' => $new['total_ms'],

		'speedup' => $speedup,
		'percent' => $percent,

		'old_mem_kb' => $old['memory_delta_kb'],
		'new_mem_kb' => $new['memory_delta_kb'],

		'old_peak_kb' => $old['peak_delta_kb'],
		'new_peak_kb' => $new['peak_delta_kb'],
	];
}

/**
 * Print comparison result.
 */
function printComparison(array $r): void {
	printf(
		"%-32s | OLD %10.1f ns | NEW %10.1f ns | %7.2fx faster | %7.2f%% improvement\n",
		$r['label'],
		$r['old_avg_ns'],
		$r['new_avg_ns'],
		$r['speedup'],
		$r['percent']
	);
}

/**
 * Print benchmark result.
 */
function printResult(array $result): void {
	printf(
		"%-35s | %8d it | %10.3f ms | %12.1f ns/op | %+10.2f KB | peak %+10.2f KB\n",
		$result['label'],
		$result['iterations'],
		$result['total_ms'],
		$result['avg_ns'],
		$result['memory_delta_kb'],
		$result['peak_delta_kb']
	);
}

/**
 * Validate BinaryMask correctness.
 */
function validateBinaryMask(array $bits): void {
	foreach ([BinaryMask::class, BinaryMaskNew::class] as $class) {
		$shifted = 0;

		$bytes = $class::toBytes($bits, true, $shifted);
		$data = $class::toBinData($bits, true, $shifted);
		$decoded = $class::fromBinData($data, $shifted);

		$hex = $class::toHexString($bits, true, true);
		$bin = $class::toBinString($bits, true, true);

		$expectedData = pack('C*', ...$bytes);

		$sortedOriginal = $bits;
		sort($sortedOriginal);

		$sortedDecoded = $decoded;
		sort($sortedDecoded);

		if ($expectedData !== $data) {
			throw new RuntimeException('Packed binary data mismatch');
		}

		if ($sortedOriginal !== $sortedDecoded) {
			throw new RuntimeException(
				sprintf(
					'Roundtrip mismatch. Expected [%s], got [%s]',
					implode(', ', $sortedOriginal),
					implode(', ', $sortedDecoded)
				)
			);
		}

		if (strlen(str_replace(' ', '', $hex)) !== count($bytes) * 2) {
			throw new RuntimeException(
				sprintf(
					'Invalid hex string length. Expected [%s], got [%s]',
					count($bytes) * 2,
					strlen(str_replace(' ', '', $hex)),
				)
			);
		}

		if (strlen(str_replace(' ', '', $bin)) !== count($bytes) * 8) {
			throw new RuntimeException(
				sprintf(
					'Invalid binary string length. Expected [%s], got [%s]',
					count($bytes) * 8,
					strlen(str_replace(' ', '', $bin)),
				)
			);
		}
	}
}

/**
 * Validate BinaryIds correctness.
 */
function validateBinaryIds(array $bits): void {
	foreach ([BinaryIds::class, BinaryIdsNew::class] as $class) {
		$ids = array_map(
			static fn (int $bit): int => $bit + 1,
			$bits
		);

		$shifted = 0;

		$data = $class::toBinData($ids, true, $shifted);
		$decoded = $class::fromBinData($data, $shifted);

		sort($ids);
		sort($decoded);

		if ($ids !== $decoded) {
			throw new RuntimeException(
				sprintf(
					$class . ' mismatch. Expected [%s], got [%s]',
					implode(', ', $ids),
					implode(', ', $decoded)
				)
			);
		}
	}
}

/*
|--------------------------------------------------------------------------
| DATASETS
|--------------------------------------------------------------------------
*/

$datasets = [
	'small_sparse' => generateBits(16, 512),
	'medium_sparse' => generateBits(128, 8192),
	'large_sparse' => generateBits(1024, 131072),

	'small_sorted' => generateBits(16, 512, true),
	'medium_sorted' => generateBits(128, 8192, true),
	'large_sorted' => generateBits(1024, 131072, true),
];

$datasets['empty'] = [];
$datasets['single_zero'] = [0];
$datasets['single_one'] = [1];
$datasets['single_high'] = [100000];
$datasets['byte_boundary'] = [7, 8, 15, 16];
$datasets['dense_small'] = range(0, 255);
$datasets['dense_large'] = range(0, 4095);

foreach ($datasets as $name => $bits) {
	validateBinaryMask($bits);
	validateBinaryIds($bits);
}

echo PHP_EOL;
echo str_repeat('=', 120) . PHP_EOL;
echo "BinaryMask Benchmark" . PHP_EOL;
echo str_repeat('=', 120) . PHP_EOL;

foreach ($datasets as $datasetName => $bits) {
	echo PHP_EOL;
	echo "Dataset: {$datasetName}" . PHP_EOL;
	echo str_repeat('-', 120) . PHP_EOL;

	$iterations = match (true) {
		count($bits) <= 16 => 200000,
		count($bits) <= 128 => 50000,
		default => 10000,
	};

	printComparison(benchmarkComparison(
		'toBytes()',
		static function () use ($bits): void {
			$shifted = 0;
			BinaryMask::toBytes($bits, true, $shifted);
		},
		static function () use ($bits): void {
			$shifted = 0;
			BinaryMaskNew::toBytes($bits, true, $shifted);
		},
		$iterations
	));

	printComparison(benchmarkComparison(
		'toBinData()',
		static function () use ($bits): void {
			$shifted = 0;
			BinaryMask::toBinData($bits, true, $shifted);
		},
		static function () use ($bits): void {
			$shifted = 0;
			BinaryMaskNew::toBinData($bits, true, $shifted);
		},
		$iterations
	));

	printComparison(benchmarkComparison(
		'toBinString()',
		static function () use ($bits): void {
			$shifted = 0;
			BinaryMask::toBinString($bits, false, true, $shifted);
		},
		static function () use ($bits): void {
			$shifted = 0;
			BinaryMaskNew::toBinString($bits, false, true, $shifted);
		},
		$iterations
	));

	printComparison(benchmarkComparison(
		'toHexString()',
		static function () use ($bits): void {
			$shifted = 0;
			BinaryMask::toHexString($bits, false, true, $shifted);
		},
		static function () use ($bits): void {
			$shifted = 0;
			BinaryMaskNew::toHexString($bits, false, true, $shifted);
		},
		$iterations
	));

	$shiftedOld = 0;
	$binDataOld = BinaryMask::toBinData($bits, true, $shiftedOld);

	$shiftedNew = 0;
	$binDataNew = BinaryMaskNew::toBinData($bits, true, $shiftedNew);

	printComparison(benchmarkComparison(
		'fromBinData()',
		static function () use ($binDataOld, $shiftedOld): void {
			BinaryMask::fromBinData($binDataOld, $shiftedOld);
		},
		static function () use ($binDataNew, $shiftedNew): void {
			BinaryMaskNew::fromBinData($binDataNew, $shiftedNew);
		},
		$iterations
	));

	/*
	|--------------------------------------------------------------------------
	| BinaryIds
	|--------------------------------------------------------------------------
	*/

	$ids = array_map(
		static fn (int $bit): int => $bit + 1,
		$bits
	);

	printComparison(benchmarkComparison(
		'BinaryIds::toBytes()',
		static function () use ($ids): void {
			$shifted = 0;
			BinaryIds::toBytes($ids, true, $shifted);
		},
		static function () use ($ids): void {
			$shifted = 0;
			BinaryIdsNew::toBytes($ids, true, $shifted);
		},
		$iterations
	));

	$shiftedOld = 0;
	$idDataOld = BinaryIds::toBinData($ids, true, $shiftedOld);

	$shiftedNew = 0;
	$idDataNew = BinaryIdsNew::toBinData($ids, true, $shiftedNew);

	printComparison(benchmarkComparison(
		'BinaryIds::fromBinData()',
		static function () use ($idDataOld, $shiftedOld): void {
			BinaryIds::fromBinData($idDataOld, $shiftedOld);
		},
		static function () use ($idDataNew, $shiftedNew): void {
			BinaryIdsNew::fromBinData($idDataNew, $shiftedNew);
		},
		$iterations
	));
}

echo PHP_EOL;
echo str_repeat('=', 120) . PHP_EOL;
echo "Done." . PHP_EOL;
echo str_repeat('=', 120) . PHP_EOL;
```

Tested on PHP 8.5.0. Core i7 11700F.